### PR TITLE
feat: set Swedish as default admin language

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@payloadcms/plugin-seo": "3.44.0",
     "@payloadcms/richtext-lexical": "3.44.0",
     "@payloadcms/storage-vercel-blob": "^3.44.0",
+    "@payloadcms/translations": "3.44.0",
     "@payloadcms/ui": "3.44.0",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-label": "^2.0.2",

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -1,6 +1,7 @@
 // storage-adapter-import-placeholder
 import { sqliteAdapter } from '@payloadcms/db-sqlite'
 import { vercelBlobStorage } from '@payloadcms/storage-vercel-blob'
+import { sv } from '@payloadcms/translations/languages/sv'
 
 import sharp from 'sharp' // sharp-import
 import path from 'path'
@@ -36,6 +37,10 @@ export default buildConfig({
       baseDir: path.resolve(dirname),
     },
     user: Users.slug,
+    dateFormat: 'yyyy-MM-dd HH:mm:ss',
+    meta: {
+      titleSuffix: ' - Freelancing Hairdresser',
+    },
     livePreview: {
       breakpoints: [
         {
@@ -61,6 +66,10 @@ export default buildConfig({
   },
   // This config helps us configure global or default features that the other editors can inherit
   editor: defaultLexical,
+  i18n: {
+    supportedLanguages: { sv },
+    fallbackLanguage: 'sv',
+  },
   db: sqliteAdapter({
     client: {
       url: process.env.DATABASE_URI || '',


### PR DESCRIPTION
Set Swedish as the default language in PayloadCMS admin mode.

## Changes
- Added @payloadcms/translations package to dependencies
- Imported Swedish language translations
- Configured i18n with Swedish as fallback language
- Updated PayloadCMS admin configuration

Closes #1

Generated with [Claude Code](https://claude.ai/code)